### PR TITLE
feat: participant lives, gain and loss

### DIFF
--- a/chaintrap/facets/arena/ArenaFacet.sol
+++ b/chaintrap/facets/arena/ArenaFacet.sol
@@ -125,7 +125,7 @@ contract ArenaFacet is
         } else if (
             // 4. remove a single life, and halt if the participant lives are exhausted.
             LibTranscript.arrayContains(
-                t._transitionTypes().livesIncrement,
+                t._transitionTypes().livesDecrement,
                 argument.proof.transitionType
             )
         ) {

--- a/chaintrap/facets/arena/ArenaFacet.sol
+++ b/chaintrap/facets/arena/ArenaFacet.sol
@@ -87,14 +87,15 @@ contract ArenaFacet is
 
         // if there was any issue with the proof, entryReveal reverts
 
-        // 1. if the choice type was declared as a victory condition,
-        // complete the game and transfer ownership to the participant.
         if (
             LibTranscript.arrayContains(
                 t._transitionTypes().victoryTransitions,
                 argument.proof.transitionType
             )
         ) {
+            // 1. if the choice type was declared as a victory condition,
+            // complete the game and transfer ownership to the participant.
+
             // complete is an irreversible state, no code exists to
             // 'un-complete'. this method can only be called by the current
             // holder of the game transcript token
@@ -113,14 +114,36 @@ contract ArenaFacet is
                 1,
                 argument.data
             );
-            // 2. if the choice type was declared as a participant halt condition,
-            // halt the participant.
+        } else if (
+            LibTranscript.arrayContains(
+                t._transitionTypes().livesIncrement,
+                argument.proof.transitionType
+            )
+        ) {
+            // 3. Add a single life.
+            t.trialistAddLives(argument, 1);
+        } else if (
+            // 4. remove a single life, and halt if the participant lives are exhausted.
+            LibTranscript.arrayContains(
+                t._transitionTypes().livesIncrement,
+                argument.proof.transitionType
+            )
+        ) {
+            // 3. Add a single life.
+            if (!t.trialistApplyFatality(argument)) {
+                return; // not fatal
+            }
+            // then the player ran out of lives
+            t.haltParticipant(argument);
         } else if (
             LibTranscript.arrayContains(
                 t._transitionTypes().haltParticipantTransitions,
                 argument.proof.transitionType
             )
         ) {
+            // 2. if the choice type was declared as a participant halt condition,
+            // halt the participant. Note that this by passes lives
+
             t.haltParticipant(argument);
         } else {
             // "reveal" the choices. we say reveal, but he act of including them

--- a/lib/interfaces/ITranscriptErrors.sol
+++ b/lib/interfaces/ITranscriptErrors.sol
@@ -28,3 +28,6 @@ error Transcript_InvalidEntry();
 error Transcript_OutcomeIllegal();
 error Transcript_OutcomeExpectedProof();
 error Transcript_OutcomeVerifyFailed();
+error Transcript_TrialistIsInitialised();
+error Transcript_TrialistNotInitialised();
+error Transcript_TrialistInvalidInitArgs();

--- a/lib/interfaces/ITranscriptEvents.sol
+++ b/lib/interfaces/ITranscriptEvents.sol
@@ -75,4 +75,17 @@ interface ITranscriptEvents {
         address indexed participant,
         uint256 lastEID
     );
+
+    event TranscriptParticipantLivesAdded(
+        uint256 indexed id,
+        address indexed participant,
+        uint256 lives,
+        uint256 added
+    );
+    event TranscriptParticipantLivesLost(
+        uint256 indexed id,
+        address indexed participant,
+        uint256 lives,
+        uint256 lost
+    );
 }

--- a/lib/libtranscriptstructs.sol
+++ b/lib/libtranscriptstructs.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.9;
+
+/// @dev general structs for libtranscripts.sol live here
+import {ProofLeaf} from "lib/libproofstack.sol";
+import {TrialistInitArgs} from "lib/libtrialiststate.sol";
+
+/// @dev the arguments necessary for creating a game.
+/// Notice: this struct nests other structs so, due to our use of ERC 2535,
+/// cannot be put in an array.
+struct TranscriptInitArgs {
+    /// @dev nft uri for the game token
+    string tokenURI;
+    /// @dev limits the number of participants. set zero for unlimited.
+    uint256 registrationLimit;
+    /// @dev notice: nested struct. DONT store the outer struct in a storage array (incompatible with diamond storage)
+    /// The trialist init args are provided when the game is created so they are
+    /// known to prospective participants before they register. (So lives cant be set to zero for example)
+    TrialistInitArgs trialistArgs;
+    /// @dev a rootLabel identifies a root. it can be a string (eg a name), a
+    /// token id, an address whatever, it must be keccak hashed if it is a
+    /// dynamic type (string or bytes). Note: we don't do bytes or string
+    /// because those can't be indexed in log topics.
+    bytes32[] rootLabels;
+    /// @dev roots is an array of merkle tree roots. each is associated with an entry in rootLabels.
+    bytes32[] roots;
+    // Before participants are expected to register, the guardian must commit to
+    // the legitemate choice input, and transition types. And the various
+    // furniture types.
+    uint256[] choiceInputTypes;
+    uint256[] transitionTypes;
+    // At least one victory transition type must be included.
+    uint256[] victoryTransitionTypes;
+    uint256[] haltParticipantTransitionTypes; // death or retirement
+    uint256[] livesIncrement;
+    uint256[] livesDecrement;
+
+    // TODO: guardian "house" wins If the game eid reaches this, the game
+    // terminates with the guardian victorious.
+    // uint256 deadlineEID;
+}
+
+struct TranscriptStartArgs {
+    /// @dev choices available to each participant at the start of the game.
+    /// Each entry is a single ProofLeaf which contains the set of exit choices
+    /// available to the registrant at their start location.
+    /// The accompanying data
+    /// Note: there is some scope for abuse while this can be set arbitrarily
+    /// (eg self participation and setting self next to the exit).  When we do
+    /// furniture, tricks and treats these will be subject to some controls.
+    /// Also, we have yet to add any notion of randomness.
+    ProofLeaf[] choices;
+    /// @dev data for the particpant starts
+    bytes[] data;
+    /// @dev the rootLabel and proofs for each of the choices
+    bytes32 rootLabel;
+    bytes32[][] proofs;
+}

--- a/lib/libtrialiststate.sol
+++ b/lib/libtrialiststate.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.9;
+
+import {TranscriptInitArgs} from "lib/libtranscriptstructs.sol";
+
+struct TrialistState {
+    uint256 flags;
+    uint256 lives;
+}
+
+struct TrialistInitArgs {
+    uint256 flags;
+    uint256 lives;
+}
+
+uint256 constant TRIALISTSTATE_FLAG_INITIALISED = 0x0000000000000000000000000000000000000000000000000000000000000001;
+
+/// ---------------------------
+/// @dev TrialistState read methods
+
+function trialistIsInitialised(
+    TrialistState storage state
+) view returns (bool) {
+    return
+        (state.flags & TRIALISTSTATE_FLAG_INITIALISED) ==
+        TRIALISTSTATE_FLAG_INITIALISED;
+}
+
+function trialistInitCheck(TrialistInitArgs calldata args) pure returns (bool) {
+    if (args.lives == 0) return false;
+    return true;
+}
+
+/// ---------------------------
+/// @dev TrialistState update methods
+/// NOTICE! The caller is responsible for doing the appropriate checks (by calling
+/// trialistInitCheck for example), these functions are effects only
+function trialistInit(
+    TrialistState storage state,
+    TrialistInitArgs storage args
+) {
+    state.flags = args.flags;
+
+    // Whatever other flags are set, the INITIALISED flag is un-conditional
+    state.flags |= TRIALISTSTATE_FLAG_INITIALISED;
+    state.lives = args.lives;
+}

--- a/tests/forge/tests/LibTranscript__init.t.sol
+++ b/tests/forge/tests/LibTranscript__init.t.sol
@@ -6,8 +6,10 @@ import "forge-std/Vm.sol";
 
 import {Transcript_IsInitialised, Transcript_VerifyFailed} from "lib/libtranscript.sol";
 import {LibTranscript, Transcript, TranscriptInitArgs} from "lib/libtranscript.sol";
+import {TrialistInitArgs} from "lib/libtrialiststate.sol";
 
 import {TranscriptWithFactory, TranscriptInitUtils, Transcript2KnowProofUtils } from "tests/TranscriptUtils.sol";
+import {minimalyValidInitArgs} from "tests/TranscriptUtils.sol";
 
 contract LibGame__init is
     TranscriptWithFactory,
@@ -36,12 +38,15 @@ contract LibGame__init is
         f._init(1, address(1), TranscriptInitArgs({
             tokenURI: "tokenURI",
             registrationLimit: 2,
+            trialistArgs: TrialistInitArgs({flags: 0, lives: 1}),
             rootLabels:new bytes32[](1),
             roots:new bytes32[](2),
             choiceInputTypes: new uint256[](1),
             transitionTypes: new uint256[](2),
             victoryTransitionTypes: new uint256[](2),
-            haltParticipantTransitionTypes: new uint256[](1)
+            haltParticipantTransitionTypes: new uint256[](1),
+            livesIncrement: new uint256[](1),
+            livesDecrement: new uint256[](1)
             }
             ));
     }
@@ -52,12 +57,15 @@ contract LibGame__init is
         f._init(1, address(1), TranscriptInitArgs({
             tokenURI: "tokenURI",
             registrationLimit: 1,
+            trialistArgs: TrialistInitArgs({flags: 0, lives: 1}),
             rootLabels:new bytes32[](2),
             roots:new bytes32[](1),
             choiceInputTypes: new uint256[](1),
             transitionTypes: new uint256[](2),
             victoryTransitionTypes: new uint256[](2),
-            haltParticipantTransitionTypes: new uint256[](1)
+            haltParticipantTransitionTypes: new uint256[](1),
+            livesIncrement: new uint256[](1),
+            livesDecrement: new uint256[](1)
             }
             ));
     }
@@ -74,12 +82,15 @@ contract LibGame__init is
         f._init(1, address(1), TranscriptInitArgs({
             tokenURI: "tokenURI",
             registrationLimit: 2,
+            trialistArgs: TrialistInitArgs({flags: 0, lives: 1}),
             rootLabels:new bytes32[](2),
             roots:new bytes32[](2),
             choiceInputTypes: new uint256[](1),
             transitionTypes: new uint256[](2),
             victoryTransitionTypes: new uint256[](2),
-            haltParticipantTransitionTypes: new uint256[](1)
+            haltParticipantTransitionTypes: new uint256[](1),
+            livesIncrement: new uint256[](1),
+            livesDecrement: new uint256[](1)
             }
             ));
     }

--- a/tests/forge/tests/LibTranscript_checkRoot.t.sol
+++ b/tests/forge/tests/LibTranscript_checkRoot.t.sol
@@ -6,6 +6,8 @@ import "forge-std/Vm.sol";
 
 import {Transcript_IsInitialised, Transcript_VerifyFailed} from "lib/libtranscript.sol";
 import {LibTranscript, Transcript, TranscriptInitArgs} from "lib/libtranscript.sol";
+import {TrialistInitArgs} from "lib/libtrialiststate.sol";
+import {minimalyValidInitArgs} from "tests/TranscriptUtils.sol";
 
 import {TranscriptWithFactory, TranscriptInitUtils } from "tests/TranscriptUtils.sol";
 
@@ -49,12 +51,15 @@ contract LibGame_checkRoot is
         f._init(1, address(1), TranscriptInitArgs({
             tokenURI: "tokenURI",
             registrationLimit: 1,
+            trialistArgs: TrialistInitArgs({flags: 0, lives: 1}),
             rootLabels:rootLabels,
             roots:roots,
             choiceInputTypes: new uint256[](1),
             transitionTypes: new uint256[](2),
             victoryTransitionTypes: new uint256[](2),
-            haltParticipantTransitionTypes: new uint256[](1)           
+            haltParticipantTransitionTypes: new uint256[](1),
+            livesIncrement: new uint256[](1),
+            livesDecrement: new uint256[](1)
             }
             ));
 

--- a/tests/forge/tests/LibTranscript_verifyRoot.t.sol
+++ b/tests/forge/tests/LibTranscript_verifyRoot.t.sol
@@ -6,6 +6,7 @@ import "forge-std/Vm.sol";
 
 import {Transcript_IsInitialised, Transcript_VerifyFailed} from "lib/libtranscript.sol";
 import {LibTranscript, Transcript, TranscriptInitArgs} from "lib/libtranscript.sol";
+import {TrialistInitArgs} from "lib/libtrialiststate.sol";
 
 import {TranscriptWithFactory, TranscriptInitUtils } from "tests/TranscriptUtils.sol";
 
@@ -49,12 +50,15 @@ contract LibGame_verifyRoot is
         f._init(1, address(1), TranscriptInitArgs({
             tokenURI: "tokenURI",
             registrationLimit: 2,
+            trialistArgs: TrialistInitArgs({flags: 0, lives: 1}),
             rootLabels:rootLabels,
             roots:roots,
             choiceInputTypes: new uint256[](1),
             transitionTypes: new uint256[](2),
             victoryTransitionTypes: new uint256[](2),
-            haltParticipantTransitionTypes: new uint256[](1)
+            haltParticipantTransitionTypes: new uint256[](1),
+            livesIncrement: new uint256[](1),
+            livesDecrement: new uint256[](1)
             }
             ));
 

--- a/tests/forge/tests/TranscriptUtils.sol
+++ b/tests/forge/tests/TranscriptUtils.sol
@@ -6,6 +6,7 @@ import "forge-std/Vm.sol";
 
 import {TranscriptInitArgs} from "lib/libtranscript.sol";
 import {LibTranscript, TranscriptStartArgs, TranscriptOutcome} from "lib/libtranscript.sol";
+import {TrialistInitArgs} from "lib/libtrialiststate.sol";
 
 import {HEVM_ADDRESS} from "tests/constants.sol";
 import {TranscriptFactory} from "tests/TranscriptFactory.sol";
@@ -23,20 +24,25 @@ contract TranscriptWithFactory {
     }
 }
 
+function minimalyValidInitArgs() pure returns (TranscriptInitArgs memory) {
+    return TranscriptInitArgs({
+        tokenURI: "tokenURI",
+        registrationLimit: 2,
+        trialistArgs: TrialistInitArgs({flags: 0, lives: 1}),
+        rootLabels:new bytes32[](1),
+        roots:new bytes32[](1),
+        choiceInputTypes: new uint256[](1),
+        transitionTypes: new uint256[](2),
+        victoryTransitionTypes: new uint256[](2),
+        haltParticipantTransitionTypes: new uint256[](1),
+        livesIncrement: new uint256[](1),
+        livesDecrement: new uint256[](1)
+        }
+        );
+}
+
+
 contract TranscriptInitUtils {
-    function minimalyValidInitArgs() internal pure returns (TranscriptInitArgs memory) {
-        return TranscriptInitArgs({
-            tokenURI: "tokenURI",
-            registrationLimit: 2,
-            rootLabels:new bytes32[](1),
-            roots:new bytes32[](1),
-            choiceInputTypes: new uint256[](1),
-            transitionTypes: new uint256[](2),
-            victoryTransitionTypes: new uint256[](2),
-            haltParticipantTransitionTypes: new uint256[](1)
-            }
-            );
-    }
     function initArgsWith1Root(bytes32 label, bytes32 root) internal pure returns (TranscriptInitArgs memory) {
         bytes32[] memory labels = new bytes32[](1);
         bytes32[] memory roots = new bytes32[](1);
@@ -45,12 +51,15 @@ contract TranscriptInitUtils {
         return TranscriptInitArgs({
             tokenURI: "tokenURI",
             registrationLimit: 2,
+            trialistArgs: TrialistInitArgs({flags: 0, lives: 1}),
             rootLabels: labels,
             roots: roots,
             choiceInputTypes: new uint256[](1),
             transitionTypes: new uint256[](2),
             victoryTransitionTypes: new uint256[](2),
-            haltParticipantTransitionTypes: new uint256[](1)
+            haltParticipantTransitionTypes: new uint256[](1),
+            livesIncrement: new uint256[](1),
+            livesDecrement: new uint256[](1)
             }
             );
     }

--- a/tests/hh/tests/libtranscript_createGame2.js
+++ b/tests/hh/tests/libtranscript_createGame2.js
@@ -18,6 +18,7 @@ describe("LibTranscript_createGame2", async function () {
     let tx = await arena.createGame({
       tokenURI: "",
       registrationLimit: 2,
+      trialistArgs: { flags: 0, lives: 1 },
       rootLabels: [ethers.utils.formatBytes32String("a-root-label")],
       roots: [
         "0x141d529a677497c1e718dcaea00c5ee952720942c8a43e9fda2c38ab24cfb562",
@@ -26,6 +27,8 @@ describe("LibTranscript_createGame2", async function () {
       transitionTypes: [2, 3],
       victoryTransitionTypes: [4],
       haltParticipantTransitionTypes: [],
+      livesIncrement: [],
+      livesDecrement: [],
     });
     let r = await tx.wait();
     expect(r.status).to.equal(1);

--- a/tests/hh/tests/libtranscript_helpers.js
+++ b/tests/hh/tests/libtranscript_helpers.js
@@ -21,6 +21,7 @@ export async function createGame(arena, params) {
   let tx = await arena.createGame({
     tokenURI: params.tokenURI ?? "",
     registrationLimit: params.registrationLimit ?? 3,
+    trialistArgs: params.trialistArgs,
     rootLabels,
     roots,
     choiceInputTypes: params.choiceInputTypes.map(conditionInput),
@@ -28,6 +29,8 @@ export async function createGame(arena, params) {
     victoryTransitionTypes: params.victoryTransitionTypes.map(conditionInput),
     haltParticipantTransitionTypes:
       params.haltParticipantTransitionTypes.map(conditionInput),
+    livesIncrement: params.livesIncrement.map(conditionInput),
+    livesDecrement: params.livesDecrement.map(conditionInput),
   });
   let r = await tx.wait();
   return { tx, r, rootLabels, roots, labeled };

--- a/tests/hh/tests/libtranscript_registerParticipant.js
+++ b/tests/hh/tests/libtranscript_registerParticipant.js
@@ -19,6 +19,7 @@ describe("LibTranscript_registerParticipant", async function () {
     let { r } = await createGame(arena, {
       tokenURI: "",
       registrationLimit: 2,
+      trialistArgs: { flags: 0, lives: 1 },
       roots: {
         a_root_label:
           "0x141d529a677497c1e718dcaea00c5ee952720942c8a43e9fda2c38ab24cfb562",
@@ -27,6 +28,8 @@ describe("LibTranscript_registerParticipant", async function () {
       transitionTypes: [2, 3],
       victoryTransitionTypes: [4],
       haltParticipantTransitionTypes: [],
+      livesIncrement: [],
+      livesDecrement: [],
     });
 
     expect(r.status).to.equal(1);


### PR DESCRIPTION
Support an openable chest that grants a life, and update death traps to respect that.

* Allow for a trialist to have 'lives'.
* Add transition types for incrementing and decrimenting player lives
* If a life decriment results in 0 lives, halt the participant